### PR TITLE
Add Pyomo solver optimizer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,8 @@ $ python -m venv .venv && source .venv/bin/activate
 $ pip install -e .[dev]
 ```
 
-> **Dependencies**: `numpy`, `pandas`, `matplotlib` (all MIT/BSD licenses).
+> **Dependencies**: `numpy`, `pandas`, `matplotlib`, `pyomo` (all MIT/BSD licenses).
+> To run the solver-based optimiser you also need a MILP solver such as **CBC**.
 
 ## Quick start
 
@@ -115,6 +116,10 @@ The script will:
 
 Feel free to replace the sample inflow series with your own CSV data.
 
+To use the Pyomo-based optimisation model instead of the greedy heuristic,
+call `WECAnalyzer.simulate(optimizer="pyomo")`.  Ensure that Pyomo and a solver
+(for example `cbc`) are installed and available on your `PATH`.
+
 ## Testing
 
 Unit tests live under **`tests/`** and rely on **pytest**:
@@ -127,7 +132,7 @@ A minimal dataset in `tests/fixtures/` guarantees ≤ 0.5 s runtime.
 
 ## Roadmap
 
-* ⚙️  Replace greedy heuristics with MILP solver (Pyomo / CBC).
+* ⚙️  Provide solver-based optimisation via Pyomo/CBC.
 * 📈  Add LiveCharts‑like interactive dashboard via Plotly.
 * 🌐  Publish REST API (FastAPI) for remote scenario runs.
 

--- a/wec/optimizers/__init__.py
+++ b/wec/optimizers/__init__.py
@@ -21,4 +21,7 @@ def get(name: str = "greedy") -> AbstractOptimizer:
     if name == "greedy":
         from .greedy import GreedyOptimizer
         return GreedyOptimizer()
+    if name == "pyomo":
+        from .pyomo_optimizer import PyomoOptimizer
+        return PyomoOptimizer()
     raise ValueError(f"Unknown optimizer '{name}'")

--- a/wec/optimizers/pyomo_optimizer.py
+++ b/wec/optimizers/pyomo_optimizer.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List
+import pyomo.environ as pyo
+
+from . import AbstractOptimizer
+from ..core.optimizer import optimise_year
+from ..core.month_selector import OperationMode
+from ..domain.geometry import Geometry
+from ..domain.static_levels import StaticLevels
+from ..domain.hydrological_series import HydrologicalSeries
+
+
+class PyomoOptimizer(AbstractOptimizer):
+    """Wrapper that builds and solves a Pyomo model."""
+
+    def __init__(self, solver: str = "cbc") -> None:
+        self.solver = solver
+
+    def compute_dV(
+        self,
+        geom: Geometry,
+        levels: StaticLevels,
+        series: HydrologicalSeries,
+        modes: List[OperationMode],
+    ) -> List[float]:
+        model = optimise_year(
+            geom,
+            levels,
+            series,
+            modes,
+            solver=self.solver,
+        )
+        dv = [pyo.value(model.dV[t]) for t in model.T]
+        return dv
+


### PR DESCRIPTION
## Summary
- extend `optimise_year` to optionally solve using a Pyomo solver
- implement `PyomoOptimizer` that wraps that model
- expose the new optimizer via the `get()` factory
- document how to run solver-based optimisation in README

## Testing
- `python -m py_compile wec/optimizers/pyomo_optimizer.py wec/core/optimizer.py wec/optimizers/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad0ed7654832aa430508dd81d3adc